### PR TITLE
Fix Dotenv::Railtie.overload to keep .env files priority policy

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -45,7 +45,7 @@ module Dotenv
     #
     # Same as `load`, but will override existing values in `ENV`
     def overload
-      Dotenv.overload(*dotenv_files)
+      Dotenv.overload(*dotenv_files.reverse)
     end
 
     # Internal: `Rails.root` is nil in Rails 4.1 before the application is

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -113,8 +113,8 @@ describe Dotenv::Railtie do
       )
     end
 
-    it "overloads .env.test with .env" do
-      expect(ENV["DOTENV"]).to eql("true")
+    it "overloads .env with .env.test" do
+      expect(ENV["DOTENV"]).to eql("test")
     end
 
     context "when loading a file containing already set variables" do
@@ -125,7 +125,7 @@ describe Dotenv::Railtie do
 
         expect do
           subject
-        end.to(change { ENV["DOTENV"] }.from("predefined").to("true"))
+        end.to(change { ENV["DOTENV"] }.from("predefined").to("test"))
       end
     end
   end


### PR DESCRIPTION
https://github.com/bkeepers/dotenv/issues/424